### PR TITLE
✨ Feat: curring partial

### DIFF
--- a/assignment/src/curring-partial.ts
+++ b/assignment/src/curring-partial.ts
@@ -1,0 +1,34 @@
+/*
+  const join = (a, b, c) => {
+    return `${a}_${b}_${c}`
+  }
+  const curriedJoin = curry(join)
+  curriedJoin(1, 2, 3) // '1_2_3'
+  curriedJoin(1)(2, 3) // '1_2_3'
+  curriedJoin(1, 2)(3) // '1_2_3'
+*/
+
+type CurryFunction<T> = (...args: any[]) => T
+
+const curry = <T>(fn: CurryFunction<T>) => {
+  const curried = (...args: any[]) => {
+    if (fn.length === args.length) {
+      return fn(...args) as ReturnType<CurryFunction<T>>
+    }
+
+    return (...args2: any[]) => curried.apply(null, [...args, ...args2]) as T
+  }
+
+  return curried as CurryFunction<any>
+}
+
+type JoinFunction = (...args: any[]) => string
+
+const join: JoinFunction = (a, b, c) => {
+  return `${a}_${b}_${c}`
+}
+
+const curriedJoin = curry(join)
+console.log(curriedJoin(1, 2, 3))
+console.log(curriedJoin(1)(2, 3))
+console.log(curriedJoin(1, 2)(3))


### PR DESCRIPTION
# Curring Partial 구현

```js
  const join = (a, b, c) => {
    return `${a}_${b}_${c}`
  }
  const curriedJoin = curry(join)
  curriedJoin(1, 2, 3) // '1_2_3'
  curriedJoin(1)(2, 3) // '1_2_3'
  curriedJoin(1, 2)(3) // '1_2_3'
```

### curring

커링은 여러 개의 인자를 받는 함수를, 하나씩 인자를 받는 여러 개의 중첩 함수로 변환하는 기법을 말한다.

- 각 인자에 대한 함수들을 변환하기 때문에 재사용 가능한 함수를 만들 수 있다. 
- 커링 기법을 사용하면, 부분적으로 적용될 수 있는 함수를 만들 수 있다. (일부 인자들의 값을 고정하여 새로운 함수를 만들 수 있다.)

Curring Partial을 구현할 때에는 전달받은 매개변수의 개수와 커링 함수가 반환하는 함수의 매개변수 개수로 구현할 수 있다.
이 과정에서 Function.prototype.apply, call, bind를 활용해서 매개변수를 넘겨주도록 구현하면 된다.

### 배운점

- 해당 코드를 구현하기 위해서는 독해 능력이 중요하다는 생각이 든다.
- 큰 문제를 잘게 쪼개기 위해서는 그만큼의 이론적 지식이 반드시 필요하다.

### 아쉬운 점.

- 재귀 함수를 구현할 때 타입 지정하는게 어렵다.. 아직 타입스크립트에 대한 지식이 부족하다고 느낀다.
- 구현하는데 5분안에 작성하지 못했고, 20분정도 걸렸다. 빠른 시간내에 폭발적인 생각을 할 수 있어야할 필요가 있다.